### PR TITLE
Nick Yeates to Sell GitHub and GitHub Enterprise like hotcakes!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# GitHubEmployement
+## Inner Source Promotion at GitHub clients
+> **Question:** How to solve the issue of Enterprise customers buying more via Inner Source methods?
+
+>> **Answer:** Employ [Nick Yeates, Inner Source Expert](https://linkedin.com/in/nickyeates)
+
+### My #1 Differentiator:
+```diff
+Inner Source Software Expert
+{
+-    What is Inner Source?
++    "The application of Open Source best practices and culture from inside a company's firewall."
+}
+```
+
+### Where I sold and implemented [Inner Source](http://innersourcecommons.org):
+* **Red Hat Inc** - I led Red Hats _Open Source Enablement consulting solution_, which brought in >$500k of revenue and encouraged enterprises toward collaborative code reuse
+* **Inner Source Commons** - I currently contribute-to and help lead this consortium started by Paypal, Nokia, Autodesk, Bosch, etc to spread the word of collaborative software development
+* **US DoD** - The US Navy employed me to lead a program-wide Inner Source initiative aimed at breaking silos and encouraging code reuse. I sold and implemented the engagement.
+* **Big Banks** - Goldman Sachs, JP Morgan Chase, Capital One, BBVA, and Banco Santander each had me lead open source workshops to influence change in their software mindset


### PR DESCRIPTION
### My #1 Differentiator:
```diff
Inner Source Software Expert
{
-    What is Inner Source?
+    "The application of Open Source best practices and culture from inside a company's firewall."
}
```

### Where I sold and implemented [Inner Source](http://innersourcecommons.org):
* **Red Hat Inc** - I led Red Hats _Open Source Enablement consulting solution_, which brought in >$500k of revenue and encouraged enterprises toward collaborative code reuse
* **Inner Source Commons** - I currently contribute-to and help lead this consortium started by Paypal, Nokia, Autodesk, Bosch, etc to spread the word of collaborative software development
* **US DoD** - The US Navy employed me to lead a program-wide Inner Source initiative aimed at breaking silos and encouraging code reuse. I sold and implemented the engagement.
* **Big Banks** - Goldman Sachs, JP Morgan Chase, Capital One, BBVA, and Banco Santander each had me lead open source workshops to influence change in their software mindset

Closes Issue [#1-GitHub Enterprise needs sales leadership](https://github.com/nyeates/GitHubEmployement/issues/1)